### PR TITLE
Implement naive rate limiting using Redis

### DIFF
--- a/src/lib/util/rateLimiter.ts
+++ b/src/lib/util/rateLimiter.ts
@@ -1,0 +1,32 @@
+// rateLimiter.ts
+import Redis from 'ioredis';
+import type TRedis from 'ioredis';
+
+export class RateLimiter {
+	private redis: TRedis;
+	private windowMs: number;
+	private maxRequests: number;
+
+	constructor(redis: TRedis, windowMs: number, maxRequests: number) {
+		this.redis = redis;
+		this.windowMs = windowMs;
+		this.maxRequests = maxRequests;
+	}
+
+	async isAllowed(ip: string): Promise<boolean> {
+		const key = `rate:${ip}`;
+		const current = await this.redis.get(key);
+
+		if (current !== null && parseInt(current) >= this.maxRequests) {
+			return false;
+		}
+
+		await this.redis
+			.multi()
+			.incr(key)
+			.expire(key, Math.ceil(this.windowMs / 1000))
+			.exec();
+
+		return true;
+	}
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,9 @@
 		password: string;
 	};
 
+	// local state to track whether we've triggered the bot once
+	let triggered = false;
+
 	// local state for whether the bot is enabled or not
 	let enablement = data.currentlyEnabled === 'true' ? true : false;
 
@@ -39,12 +42,14 @@
 		});
 
 	// call the local /api/coffeechat endpoint with POST
-	const coffeechatFormSubmit = async () =>
+	const coffeechatFormSubmit = async () => {
+		triggered = true;
 		fetch(`/api/coffeechat`, {
 			method: 'GET'
 		}).then(() => {
 			message = 'Coffee chats sent!';
 		});
+	};
 
 	// POST to /api/storeroster where the JSON body is the roster
 	const rosterFormSubmit = async () => {
@@ -81,16 +86,18 @@
 
 	<div class="row">
 		<button on:click={statusFormSubmit}>Turn {enablement ? 'Off' : 'On'}</button>
-		<button on:click={coffeechatFormSubmit}>Trigger Coffee Chats Manually</button>
+		<button on:click|once|preventDefault={coffeechatFormSubmit}
+			>Trigger Coffee Chats Manually</button
+		>
 	</div>
 
 	<form on:submit|preventDefault={rosterFormSubmit}>
-		<h2>Update Roster</h2>
+		<h2>Roster</h2>
 		<label for="roster">
-			Enter each NetID on its own line, and nothing else. <br />
+			Keep each NetID on its own line, and input nothing else. <br />
 		</label>
 		<textarea rows={10} cols={10} name="roster" bind:value={rosterText} />
-		<button class="roster" type="submit">Update Roster</button>
+		<button class="roster" type="submit">Modify Roster</button>
 	</form>
 </section>
 


### PR DESCRIPTION
This is UNTESTED! 

Why? Because testing currently sends out a shit ton of actual Slack messages, which I think is not great for team culture.

This PR shall remain open until we successfully implement MOCKING of the Slack API, Redis, and Rate Limiter using Jest/Vitest, and test the endpoint holistically in a glass-box style. The following must be tested:

- [ ] Correct rate limiting for IPs within mocked timeframes
- [ ] Bot does not interact with mocked Slack API when mocked Redis says its disabled
- [ ] Bot calls the mocked Slack API the correct number of times, with reasonable pairings, that includes everyone it should based on the fake data in the mocked Redis and mocked Slack channel.
- [ ] etc.

Only then will I allow us to actually test this rate limiting, and see if it works.

Until then, rate limiting shall do like Lenin's body in Moscow's Red Square.